### PR TITLE
Feat/us34 admin invoice show item info

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -17,11 +17,11 @@ class Admin::MerchantsController < ApplicationController
     merchant = Merchant.find(params[:id])
     # require 'pry'; binding.pry
     if merchant.update(admin_merchant_params)
-      flash[:notice] = "Succefully Updated"
+      flash[:notice] = "Succesfully Updated"
       redirect_to admin_merchant_path(merchant.id)
       # merchant.save
     else 
-      flash[:alart] = "Error: All Fields Must Be Filled In"
+      flash[:alert] = "Error: All Fields Must Be Filled In"
     end
   end
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -3,3 +3,15 @@
 <p> Status: <%= @invoice.status %> </p>
 <p> Created On: <%= @invoice.format_date %> </p>
 <p> Customer: <%= @invoice.customer.name %> </p>
+
+<div id="invoice-items">
+  <h3> Items on this Invoice </h3>
+  <ul><% @invoice.invoice_items.each do |invoice_item| %>
+    <div id="item-<%= invoice_item.id %>">
+      <li> Name: <%= invoice_item.item.name %> - 
+      Quantity: <%= invoice_item.quantity %> - 
+      Unit Price: <%= invoice_item.unit_price %> - 
+      Status: <%= invoice_item.status %> </li>
+    </div>
+  <% end %> </ul>
+</div>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Admin Invoices Show" do
   end
 
   describe '#33' do
-    it 'displays a list of all invoices in the system with a link to that admin invoices show page' do
+    it 'displays all information related to that invoice, including status, created_on date, and customer name' do
       visit admin_invoice_path(@invoice1.id)
 
       expect(page).to have_content("Invoice ##{@invoice1.id}")
@@ -70,8 +70,33 @@ RSpec.describe "Admin Invoices Show" do
       expect(page).to_not have_content("Invoice ##{@invoice3.id}")
     end
   end
-end
 
+  describe '#34' do
+    it 'displays all items from that invoice, including item name, quantity, price, and invoice item status' do
+      visit admin_invoice_path(@invoice1.id)
+
+      expect(page).to have_content("Items on this Invoice")
+      within "#invoice-items" do
+        expect(page).to have_content("#{@item1.name}")
+        expect(page).to have_content("#{@item2.name}")
+        expect(page).to_not have_content("#{@item3.name}")
+        expect(page).to_not have_content("#{@item5.name}")
+      end
+
+      within "#item-#{@invoice_item1.id}" do
+        expect(page).to have_content("#{@invoice_item1.quantity}")
+        expect(page).to have_content("#{@invoice_item1.unit_price}")
+        expect(page).to have_content("#{@invoice_item1.status}")
+      end
+
+      within "#item-#{@invoice_item2.id}" do
+        expect(page).to have_content("#{@invoice_item2.quantity}")
+        expect(page).to have_content("#{@invoice_item2.unit_price}")
+        expect(page).to have_content("#{@invoice_item2.status}")
+      end
+    end
+  end
+end
 
 
 

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Admin Merchants Show" do
       # Then I am redirected back to the merchant's admin show page where I see the updated information
       expect(current_path).to eq(admin_merchant_path(@merchant1.id))
       # And I see a flash message stating that the information has been successfully updated.
-      expect(page).to have_content("Succefully Updated")
+      expect(page).to have_content("Succesfully Updated")
 
     end
   end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Merchant Invoices Index" do
       visit merchant_invoices_path(@merchant1)
 
       within "#invoice-#{@invoice1.id}" do
-        expect(page).to have_link(@invoice1.id)
+        expect(page).to have_link(@invoice1.id.to_s)
         click_on "#{@invoice1.id}"
       end  
 


### PR DESCRIPTION
- Add to admin/invoice/show page to include information on inovice_items
- Updated some spec tests for spelling errors and organization

closes #12 