### PR TITLE
Feat/us28

### DIFF
--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,7 +1,6 @@
 <h1>Merchants</h1>
-
 <section class="enabled" >
-<p><%= "Enabled Merchants:" %></p>
+  <h2><%= "Enabled Merchants:" %></h2>
   <% @merchants.each do |merchant| %>
     <% if merchant.status == "Enabled" %>
       <%= link_to "#{merchant.name}", admin_merchant_path(merchant), method: :get %><br>
@@ -11,9 +10,8 @@
   <% end %>
 </section>
 
-
 <section class="disabled">
-<p><%= "Disabled Merchants:" %></p>
+  <h2><%= "Disabled Merchants:" %></h2>
   <% @merchants.each do |merchant| %>
     <% if merchant.status == "Disabled" %>
 

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,13 +1,25 @@
 <h1>Merchants</h1>
 
-<% @merchants.each do |merchant| %>
-  <div id="merchant-<%= merchant.id %>">
-    <%= link_to "#{merchant.name}", admin_merchant_path(merchant), method: :get %>
-    <p>Status: <%= merchant.status %></p>
+<section class="enabled" >
+<p><%= "Enabled Merchants:" %></p>
+  <% @merchants.each do |merchant| %>
     <% if merchant.status == "Enabled" %>
-      <%= button_to 'Disable', admin_merchant_path(merchant), method: :patch, params: {status: "Disabled"}  %>
-    <% else %>
-      <%= button_to 'Enable', admin_merchant_path(merchant), method: :patch, params: {status: "Enabled"}  %>
+      <%= link_to "#{merchant.name}", admin_merchant_path(merchant), method: :get %><br>
+
+      <%= button_to "Disable #{merchant.name}", admin_merchant_path(merchant), method: :patch, params: {status: "Disabled"}  %><br>
     <% end %>
-  </div>
-<% end %>
+  <% end %>
+</section>
+
+
+<section class="disabled">
+<p><%= "Disabled Merchants:" %></p>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "Disabled" %>
+
+      <%= link_to "#{merchant.name}", admin_merchant_path(merchant), method: :get %>
+     
+      <%= button_to "Enable #{merchant.name} ", admin_merchant_path(merchant), method: :patch, params: {status: "Enabled"}  %> 
+    <% end %>
+  <% end %>
+</section>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "Admin Merchants Index" do
       within '.disabled' do
         expect(page).to have_content("Disabled Merchants:")
         expect(page).to have_content("Target")
-        save_and_open_page
       end
     end
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Admin Merchants Index" do
   before(:each) do
     @merchant1 = Merchant.create(name: "Amazon")
     @merchant2 = Merchant.create(name: "Walmart")
-    @merchant3 = Merchant.create(name: "Target")
+    @merchant3 = Merchant.create(name: "Target", status: 1)
    
   end
 
@@ -39,17 +39,39 @@ RSpec.describe "Admin Merchants Index" do
       # When I visit the admin merchants index (/admin/merchants)
       visit admin_merchants_path
       # Then next to each merchant name I see a button to disable or enable that merchant.
-      within "#merchant-#{@merchant1.id}" do
-        expect(page).to have_button("Disable")
+      within ".enabled" do
+        expect(page).to have_button("Disable #{@merchant1.name}")
         # When I click this button
-        click_on("Disable")
+        click_on("Disable #{@merchant1.name}")
       end
       # Then I am redirected back to the admin merchants index
       expect(current_path).to eq(admin_merchants_path)
       # And I see that the merchant's status has changed
-      within "#merchant-#{@merchant1.id}" do
-        expect(page).to have_button("Enable")
-        expect(page).to have_content("Disabled")
+      within ".disabled" do
+        expect(page).to have_button("Enable #{@merchant1.name}")
+        # expect(page).to have_content("Status: Disabled")
+      end
+    end
+  end
+
+  describe '#us 28' do
+    it 'Has a section one for enabled merchants and the other for disabled merchants' do
+
+      # When I visit the admin merchants index (/admin/merchants)
+      visit admin_merchants_path
+      # Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
+      within ".enabled" do
+        expect(page).to have_content("Enabled Merchants:")
+        expect(page).to have_content("Amazon")
+        expect(page).to have_content("Walmart")
+
+      end
+      # And I see that each Merchant is listed in the appropriate section
+
+      within '.disabled' do
+        expect(page).to have_content("Disabled Merchants:")
+        expect(page).to have_content("Target")
+        save_and_open_page
       end
     end
   end


### PR DESCRIPTION
In this branch us 28 was implemented, This was showing two sections one for enabled merchants and the other for disabled merchants. Also refactored the view to make it cleaner.

close #19 