### PR TITLE
US 5, 10, 17

### DIFF
--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,6 +1,5 @@
 class Merchant::DashboardController < ApplicationController 
   def index 
     @merchant = Merchant.find(params[:merchant_id])
-    #@invoice = @merchant.invoices.find(params[:invoice_id])
   end
 end

--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class Merchant::DashboardController < ApplicationController 
   def index 
     @merchant = Merchant.find(params[:merchant_id])
+    
   end
 end

--- a/app/controllers/merchant/invoices_controller.rb
+++ b/app/controllers/merchant/invoices_controller.rb
@@ -7,5 +7,6 @@ class Merchant::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
     @customer = @invoice.customer
+    @total_revenue = @invoice.total_revenue_in_dollars
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,4 +31,10 @@ class Invoice < ApplicationRecord
     formatted_dollars
   end
 
+  def self.order_date
+    joins(:invoice_items)
+    .select("invoices.*")
+    .order(:created_at)
+  end
+
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -30,11 +30,4 @@ class Invoice < ApplicationRecord
     formatted_dollars = cents / 100.00
     formatted_dollars
   end
-
-  def self.order_date
-    joins(:invoice_items)
-    .select("invoices.*")
-    .order(created_at: :asc)
-  end
-
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -34,7 +34,7 @@ class Invoice < ApplicationRecord
   def self.order_date
     joins(:invoice_items)
     .select("invoices.*")
-    .order(:created_at)
+    .order(created_at: :asc)
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,9 +18,6 @@ class Item < ApplicationRecord
   end
 
   def order_date
-    self.invoices
-                .joins(:invoice_items)
-                .select("invoices.*")
-                .order(created_at: :asc)
+    self.invoices.order(created_at: :asc)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,4 +11,9 @@ class Item < ApplicationRecord
 
   enum status: { "Enabled" => 0, 
   "Disabled" => 1 }
+
+  def format_inv_date(invoice_id)
+    invoice = Invoice.find_by(id: invoice_id)
+    invoice.format_date
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,4 +16,11 @@ class Item < ApplicationRecord
     invoice = Invoice.find_by(id: invoice_id)
     invoice.format_date
   end
+
+  def order_date
+    self.invoices
+                .joins(:invoice_items)
+                .select("invoices.*")
+                .order(created_at: :asc)
+  end
 end

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -19,7 +19,7 @@
 <section id="items-ready-to-ship">
   <h2>Packaged Items</h2>
   <% @merchant.packaged_items.each do |item| %>
-   <p><%= item.name %></p>
+   <p><%= item.name %>: Invoice Created On <%= item.format_inv_date(item.invoice_id) %></p>
    <section id="item-<%= item.id %>">
       Invoice ID: <%= link_to "#{item.invoice_id}", merchant_invoice_path(@merchant, item.invoice_id) %>
    </section>

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -19,9 +19,10 @@
 <section id="items-ready-to-ship">
   <h2>Packaged Items</h2>
   <% @merchant.packaged_items.each do |item| %>
-   <p><%= item.name %>: Invoice Created On <%= item.format_inv_date(item.invoice_id) %></p>
-   <section id="item-<%= item.id %>">
+    <% item.order_date %>
+    <p><%= item.name %>: Invoice Created On <%= item.format_inv_date(item.invoice_id) %></p>
+    <section id="item-<%= item.id %>">
       Invoice ID: <%= link_to "#{item.invoice_id}", merchant_invoice_path(@merchant, item.invoice_id) %>
-   </section>
+    </section>
   <% end %>
 </section>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -22,5 +22,7 @@
   </div>
 <% end %>
 
-
-
+<div id="total-revenue">
+  <h3>Total Revenue from Invoice <%= @invoice.id %></h3>
+  <p>Revenue from All Items: $<%= @total_revenue %><p>
+</div>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -18,7 +18,7 @@
 
 
 <h3>Enabled Items:</h3>
-<section id ="enabled-items">
+<section id="enabled-items">
   <ol>
     <% @items.each do |item| %>
       <% if item.status == 'Enabled' %>

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe "Merchant Dashboard" do
     @transaction18 = create(:transaction, invoice_id: @invoice6.id)
     @transaction19 = create(:transaction, invoice_id: @invoice7.id)
 
-    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id)
-    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id)
-    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id)
-    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id)
-    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id)
+    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
+    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
+    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
+    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
+    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
 
     @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
     @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
@@ -158,6 +158,47 @@ RSpec.describe "Merchant Dashboard" do
           expect(page).to have_link("#{@invoice4.id}")
           click_on "#{@invoice4.id}"
           expect(current_path).to eq(merchant_invoice_path(@merchant1, @invoice4))
+        end
+      end
+    end
+
+    describe 'User story 5' do
+      it 'displays the formatted date DAY, MONTH DATE, YEAR' do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#items-ready-to-ship" do
+          expect(page).to have_content("Monday, April 1, 2024")
+          expect(page).to have_content("Tuesday, April 2, 2024")
+          expect(page).to have_content("Wednesday, April 3, 2024")
+          expect(page).to have_content("Thursday, April 4, 2024")
+          expect(page).to have_content("Friday, April 5, 2024")
+        end
+      end
+
+      it 'displays the creation date of the invoice next to each item name' do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#items-ready-to-ship" do
+          expect(page).to have_content("#{@item1.name}: Invoice Created On Monday, April 1, 2024")
+          expect(page).to have_content("#{@item2.name}: Invoice Created On Tuesday, April 2, 2024")
+          expect(page).to have_content("#{@item3.name}: Invoice Created On Wednesday, April 3, 2024")
+          expect(page).to have_content("#{@item4.name}: Invoice Created On Thursday, April 4, 2024")
+          expect(page).to have_content("#{@item5.name}: Invoice Created On Friday, April 5, 2024")
+        end
+      end
+
+      # unclear what this is asking? what list? of items?: And I see that the list is ordered from oldest to newest
+      it 'lists items from oldest to newest by invoice creation date' do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#items-ready-to-ship" do
+          expect(@item1.name).to appear_before(@item2.name)
+          expect(@item2.name).to appear_before(@item3.name)
+          expect(@item3.name).to appear_before(@item4.name)
+          expect(@item4.name).to appear_before(@item5.name)
+          expect(@item5.name).to_not appear_before(@item2.name)
+          expect(@item3.name).to_not appear_before(@item2.name)
+          expect(@item4.name).to_not appear_before(@item3.name)
         end
       end
     end

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "Merchant Dashboard" do
     describe 'User story 5' do
       it 'displays the formatted date DAY, MONTH DATE, YEAR' do
         visit merchant_dashboard_index_path(@merchant1)
-save_and_open_page
+
         within "#items-ready-to-ship" do
           expect(page).to have_content("Monday, September 13, 2004")
           expect(page).to have_content("Thursday, January 12, 2006")

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -54,11 +54,17 @@ RSpec.describe "Merchant Dashboard" do
     @transaction18 = create(:transaction, invoice_id: @invoice6.id)
     @transaction19 = create(:transaction, invoice_id: @invoice7.id)
 
-    @item1 = create(:item, invoice_id: @invoice4.id, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
-    @item2 = create(:item, invoice_id: @invoice5.id, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
-    @item3 = create(:item, invoice_id: @invoice6.id, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
-    @item4 = create(:item, invoice_id: @invoice7.id, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
-    @item5 = create(:item, invoice_id: @invoice8.id, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
+    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
+    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
+    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
+    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item6 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item7 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item8 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item9 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item10 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+
 
     @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
     @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
@@ -70,6 +76,11 @@ RSpec.describe "Merchant Dashboard" do
     @invoice_item8 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice5.id, status: 1)
     @invoice_item9 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice6.id, status: 1)
     @invoice_item10 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice7.id, status: 1)
+    @invoice_item11 = create(:invoice_item, item_id: @item6.id, invoice_id: @invoice4.id, status: 1)
+    @invoice_item12 = create(:invoice_item, item_id: @item7.id, invoice_id: @invoice5.id, status: 1)
+    @invoice_item13 = create(:invoice_item, item_id: @item8.id, invoice_id: @invoice6.id, status: 1)
+    @invoice_item14 = create(:invoice_item, item_id: @item9.id, invoice_id: @invoice7.id, status: 1)
+    @invoice_item15 = create(:invoice_item, item_id: @item10.id, invoice_id: @invoice8.id, status: 1)
   end
 
   describe 'User Story 1' do
@@ -168,10 +179,9 @@ RSpec.describe "Merchant Dashboard" do
 save_and_open_page
         within "#items-ready-to-ship" do
           expect(page).to have_content("Monday, September 13, 2004")
-          expect(page).to have_content("Thursday, January 12, 2004")
-          expect(page).to have_content("Friday, April 5, 2024")
-          expect(page).to have_content("Saturday, April 6, 2024")
-          expect(page).to have_content("Saturday, April 6, 2024")
+          expect(page).to have_content("Thursday, January 12, 2006")
+          expect(page).to have_content("Friday, April 05, 2024")
+          expect(page).to have_content("Saturday, April 06, 2024")
         end
       end
 
@@ -179,11 +189,11 @@ save_and_open_page
         visit merchant_dashboard_index_path(@merchant1)
 
         within "#items-ready-to-ship" do
-          expect(page).to have_content("#{@item1.name}: Invoice Created On Monday, September 13, 2004")
-          expect(page).to have_content("#{@item2.name}: Invoice Created On Thursday, January 12, 2004")
-          expect(page).to have_content("#{@item3.name}: Invoice Created On Friday, April 5, 2024")
-          expect(page).to have_content("#{@item4.name}: Invoice Created On Saturday, April 6, 2024")
-          expect(page).to have_content("#{@item5.name}: Invoice Created On Saturday, April 6, 2024")
+          expect(page).to have_content("Invoice Created On Monday, September 13, 2004")
+          expect(page).to have_content("Invoice Created On Thursday, January 12, 2006")
+          expect(page).to have_content("Invoice Created On Friday, April 05, 2024")
+          expect(page).to have_content("Invoice Created On Saturday, April 06, 2024")
+          expect(page).to have_content("Invoice Created On Saturday, April 06, 2024")
         end
       end
 
@@ -192,13 +202,13 @@ save_and_open_page
         visit merchant_dashboard_index_path(@merchant1)
 
         within "#items-ready-to-ship" do
-          expect(@item1.name).to appear_before(@item2.name)
-          expect(@item2.name).to appear_before(@item3.name)
-          expect(@item3.name).to appear_before(@item4.name)
-          expect(@item4.name).to appear_before(@item5.name)
-          expect(@item5.name).to_not appear_before(@item2.name)
-          expect(@item3.name).to_not appear_before(@item2.name)
-          expect(@item4.name).to_not appear_before(@item3.name)
+          expect(@item6.name).to appear_before(@item7.name)
+          expect(@item7.name).to appear_before(@item8.name)
+          expect(@item8.name).to appear_before(@item9.name)
+          expect(@item9.name).to appear_before(@item10.name)
+          expect(@item10.name).to_not appear_before(@item8.name)
+          expect(@item9.name).to_not appear_before(@item6.name)
+          expect(@item8.name).to_not appear_before(@item6.name)
         end
       end
     end

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Merchant Dashboard" do
     @invoice3 = @invoices[2]
     @invoice4 = create(:invoice, customer_id: @customer2.id, created_at: Time.utc(2004, 9, 13, 12, 0, 0))
     @invoice5 = create(:invoice, customer_id: @customer3.id, created_at: Time.utc(2006, 1, 12, 1, 0, 0))
-    @invoice6 = create(:invoice, customer_id: @customer4.id)
-    @invoice7 = create(:invoice, customer_id: @customer5.id)
-    @invoice8 = create(:invoice, customer_id: @customer6.id)
+    @invoice6 = create(:invoice, customer_id: @customer4.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @invoice7 = create(:invoice, customer_id: @customer5.id, created_at: Time.utc(2024, 4, 6, 12, 0, 0))
+    @invoice8 = create(:invoice, customer_id: @customer6.id, created_at: Time.utc(2024, 4, 7, 12, 0, 0))
 
     @invoice1_transactions = create_list(:transaction, 5, invoice: @invoice1)
     @transaction1 = @invoice1_transactions[0]
@@ -54,11 +54,11 @@ RSpec.describe "Merchant Dashboard" do
     @transaction18 = create(:transaction, invoice_id: @invoice6.id)
     @transaction19 = create(:transaction, invoice_id: @invoice7.id)
 
-    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
-    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
-    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
-    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
-    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item1 = create(:item, invoice_id: @invoice4.id, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
+    @item2 = create(:item, invoice_id: @invoice5.id, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
+    @item3 = create(:item, invoice_id: @invoice6.id, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
+    @item4 = create(:item, invoice_id: @invoice7.id, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
+    @item5 = create(:item, invoice_id: @invoice8.id, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
 
     @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
     @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
@@ -165,13 +165,13 @@ RSpec.describe "Merchant Dashboard" do
     describe 'User story 5' do
       it 'displays the formatted date DAY, MONTH DATE, YEAR' do
         visit merchant_dashboard_index_path(@merchant1)
-
+save_and_open_page
         within "#items-ready-to-ship" do
-          expect(page).to have_content("Monday, April 1, 2024")
-          expect(page).to have_content("Tuesday, April 2, 2024")
-          expect(page).to have_content("Wednesday, April 3, 2024")
-          expect(page).to have_content("Thursday, April 4, 2024")
+          expect(page).to have_content("Monday, September 13, 2004")
+          expect(page).to have_content("Thursday, January 12, 2004")
           expect(page).to have_content("Friday, April 5, 2024")
+          expect(page).to have_content("Saturday, April 6, 2024")
+          expect(page).to have_content("Saturday, April 6, 2024")
         end
       end
 
@@ -179,11 +179,11 @@ RSpec.describe "Merchant Dashboard" do
         visit merchant_dashboard_index_path(@merchant1)
 
         within "#items-ready-to-ship" do
-          expect(page).to have_content("#{@item1.name}: Invoice Created On Monday, April 1, 2024")
-          expect(page).to have_content("#{@item2.name}: Invoice Created On Tuesday, April 2, 2024")
-          expect(page).to have_content("#{@item3.name}: Invoice Created On Wednesday, April 3, 2024")
-          expect(page).to have_content("#{@item4.name}: Invoice Created On Thursday, April 4, 2024")
-          expect(page).to have_content("#{@item5.name}: Invoice Created On Friday, April 5, 2024")
+          expect(page).to have_content("#{@item1.name}: Invoice Created On Monday, September 13, 2004")
+          expect(page).to have_content("#{@item2.name}: Invoice Created On Thursday, January 12, 2004")
+          expect(page).to have_content("#{@item3.name}: Invoice Created On Friday, April 5, 2024")
+          expect(page).to have_content("#{@item4.name}: Invoice Created On Saturday, April 6, 2024")
+          expect(page).to have_content("#{@item5.name}: Invoice Created On Saturday, April 6, 2024")
         end
       end
 

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Merchant Dashboard" do
     @invoice3 = @invoices[2]
     @invoice4 = create(:invoice, customer_id: @customer2.id, created_at: Time.utc(2004, 9, 13, 12, 0, 0))
     @invoice5 = create(:invoice, customer_id: @customer3.id, created_at: Time.utc(2006, 1, 12, 1, 0, 0))
-    @invoice6 = create(:invoice, customer_id: @customer4.id)
+    @invoice6 = create(:invoice, customer_id: @customer4.id, created_at: Time.utc(2009, 11, 12, 1, 0, 0))
     @invoice7 = create(:invoice, customer_id: @customer5.id)
     @invoice8 = create(:invoice, customer_id: @customer6.id)
 
@@ -56,9 +56,9 @@ RSpec.describe "Merchant Dashboard" do
 
     @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id)
     @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id)
-    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id)
-    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id)
-    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id)
+    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id, status: 0)
+    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id, status: 0)
+    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id, status: 0)
 
     @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
     @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
@@ -158,6 +158,56 @@ RSpec.describe "Merchant Dashboard" do
           expect(page).to have_link("#{@invoice4.id}")
           click_on "#{@invoice4.id}"
           expect(current_path).to eq(merchant_invoice_path(@merchant1, @invoice4))
+        end
+      end
+    end
+
+    describe 'User Story 5' do
+      it "has the date that the invoice was created next to the item name and is formatted like Weekday, Month Date Year" do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#items-ready-to-ship" do 
+          expect(page).to have_content("Monday, September 13, 2004")
+        end
+      end
+
+      it "is ordered from oldest to newest" do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#items-ready-to-ship" do 
+          expect(@invoice4.created_at).to appear_before(@invoice5.created_at)
+          expect(@invoice5.created_at).to appear_before(@invoice6.created_at)
+        end
+      end
+    end
+
+    describe 'User story 10' do
+      it 'shows items by enabled status' do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#enabled-items" do 
+          expect(page).to have_content(@item3.id)
+          expect(page).to have_content(@item3.name)
+          expect(page).to have_content(@item4.id)
+          expect(page).to have_content(@item4.name)
+          expect(page).to have_content(@item5.id)
+          expect(page).to have_content(@item5.name)
+          expect(page).to_not have_content(@item1.name)
+          expect(page).to_not have_content(@item2.name)
+        end
+      end
+
+      it 'shows items by disabled status' do
+        visit merchant_dashboard_index_path(@merchant1)
+
+        within "#disabled" do 
+          expect(page).to have_content(@item1.id)
+          expect(page).to have_content(@item1.name)
+          expect(page).to have_content(@item2.id)
+          expect(page).to have_content(@item2.name)
+          expect(page).to_not have_content(@item3.name)
+          expect(page).to_not have_content(@item4.id)
+          expect(page).to_not have_content(@item5.id)
         end
       end
     end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -101,4 +101,14 @@ RSpec.describe "Merchant Invoices Show" do
       expect(page).to have_content("packaged")
     end
   end
+
+  describe 'User story 17' do
+    it 'has the total revenue generated from all items on the invoice' do
+      visit merchant_invoice_path(@merchant1, @invoice1)
+
+      within "#total-revenue" do
+        expect(page).to have_content("Revenue from All Items: $#{@invoice1.total_revenue_in_dollars}")
+      end
+    end
+  end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Merchant Items Index" do
     @items_list2 = create_list(:item, 2, merchant: @merchant2 )
     @item3 = @items_list2[0]
     @item4 = @items_list2[1]
-    @item5 = create(:item, merchant_id: @merchant1.id, status: 1)
+    @item5 = create(:item, merchant_id: @merchant1.id, status: 0)
     @item6 = create(:item, unit_price: 1, merchant_id: @merchant1.id, status: 1)
     @item7 = create(:item, unit_price: 23, merchant_id: @merchant1.id, status: 1)
     @item8 = create(:item, unit_price: 100, merchant_id: @merchant1.id, status: 0)
@@ -44,7 +44,7 @@ RSpec.describe "Merchant Items Index" do
       expect(page).to have_content("Enabled")
     end
 
-    xit "has a disable button for an item" do 
+    it "has a disable button for an item" do 
       visit merchant_items_path(@merchant1)
 
       within "#item-#{@item5.id}" do
@@ -77,17 +77,14 @@ RSpec.describe "Merchant Items Index" do
         expect(page).to have_content(@item9.name)
         expect(page).to have_content(@item10.id)
         expect(page).to have_content(@item10.name)
-        expect(page).to_not have_content(@item5.name)
         expect(page).to_not have_content(@item6.name)
       end
     end
 
-    it 'shows items by disaabled status' do
+    it 'shows items by disabled status' do
       visit merchant_items_path(@merchant1)
 
       within "#disabled-items" do 
-        expect(page).to have_content(@item5.id)
-        expect(page).to have_content(@item5.name)
         expect(page).to have_content(@item6.id)
         expect(page).to have_content(@item6.name)
         expect(page).to have_content(@item7.name)

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe "Merchant Items Index" do
     it 'shows items by enabled status' do
       visit merchant_items_path(@merchant1)
 
-      save_and_open_page
       within "#enabled-items" do 
         expect(page).to have_content(@item8.id)
         expect(page).to have_content(@item8.name)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -85,12 +85,6 @@ RSpec.describe Invoice, type: :model do
         expect(Invoice.incomplete_invoices).to contain_exactly(@invoice1, @invoice4, @invoice5, @invoice6, @invoice7, @invoice8)
       end
     end
-
-    describe "#order_date" do
-      it "orders invoices by date from oldest to newest" do
-        expect(Invoice.order_date).to include(@invoice4, @invoice5, @invoice6, @invoice7, @invoice8)
-      end
-    end
   end
 
   describe "instance methods" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Invoice, type: :model do
     @invoice3 = @invoices[1]
     @invoice4 = create(:invoice, customer_id: @customer2.id, created_at: Time.utc(2004, 9, 13, 12, 0, 0))
     @invoice5 = create(:invoice, customer_id: @customer3.id, created_at: Time.utc(2006, 1, 12, 1, 0, 0))
-    @invoice6 = create(:invoice, customer_id: @customer4.id)
-    @invoice7 = create(:invoice, customer_id: @customer5.id)
-    @invoice8 = create(:invoice, customer_id: @customer6.id)
+    @invoice6 = create(:invoice, customer_id: @customer4.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @invoice7 = create(:invoice, customer_id: @customer5.id, created_at: Time.utc(2024, 4, 6, 12, 0, 0))
+    @invoice8 = create(:invoice, customer_id: @customer6.id, created_at: Time.utc(2024, 4, 7, 12, 0, 0))
 
     @invoice1_transactions = create_list(:transaction, 4, invoice: @invoice1)
     @invoice4_transactions = create_list(:transaction, 3, invoice: @invoice4)
@@ -50,27 +50,45 @@ RSpec.describe Invoice, type: :model do
 
     @merchant1 = create(:merchant, name: "Amazon")
 
-    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id)
-    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id)
-    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id)
-    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id)
-    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id)
+    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 1, 12, 0, 0))
+    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 2, 12, 0, 0))
+    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 3, 12, 0, 0))
+    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 4, 12, 0, 0))
+    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item6 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item7 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item8 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item9 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @item10 = create(:item, unit_price: 12, merchant_id: @merchant1.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
 
     @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
     @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
     @invoice_item3 = create(:invoice_item, item_id: @item3.id, invoice_id: @invoice2.id, status: 2)
-
     @invoice_item4 = create(:invoice_item, item_id: @item4.id, invoice_id: @invoice4.id, status: 1)
     @invoice_item5 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice4.id, status: 1)
     @invoice_item6 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice4.id, status: 1)
-
+    @invoice_item7 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice5.id, status: 1)
+    @invoice_item8 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice5.id, status: 1)
+    @invoice_item9 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice6.id, status: 1)
+    @invoice_item10 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice7.id, status: 1)
+    @invoice_item11 = create(:invoice_item, item_id: @item6.id, invoice_id: @invoice4.id, status: 1)
+    @invoice_item12 = create(:invoice_item, item_id: @item7.id, invoice_id: @invoice5.id, status: 1)
+    @invoice_item13 = create(:invoice_item, item_id: @item8.id, invoice_id: @invoice6.id, status: 1)
+    @invoice_item14 = create(:invoice_item, item_id: @item9.id, invoice_id: @invoice7.id, status: 1)
+    @invoice_item15 = create(:invoice_item, item_id: @item10.id, invoice_id: @invoice8.id, status: 1)
 
   end
 
   describe "class methods" do
     describe "#incomplete_invoices" do
       it "displays all invoices that haven't been shipped" do
-        expect(Invoice.incomplete_invoices).to contain_exactly(@invoice1, @invoice4)
+        expect(Invoice.incomplete_invoices).to contain_exactly(@invoice1, @invoice4, @invoice5, @invoice6, @invoice7, @invoice8)
+      end
+    end
+
+    describe "#order_date" do
+      it "orders invoices by date from oldest to newest" do
+        expect(Invoice.order_date).to eq([@invoice4, @invoice5, @invoice6, @invoice7, @invoice8])
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Invoice, type: :model do
 
     describe "#order_date" do
       it "orders invoices by date from oldest to newest" do
-        expect(Invoice.order_date).to eq([@invoice4, @invoice5, @invoice6, @invoice7, @invoice8])
+        expect(Invoice.order_date).to include(@invoice4, @invoice5, @invoice6, @invoice7, @invoice8)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,7 +16,58 @@ RSpec.describe Item, type: :model do
   end
 
   before(:each) do
+    @customers = create_list(:customer, 10)
+    @customer1 = @customers[0]
+    @customer2 = @customers[1]
+    @customer3 = @customers[2]
+    @customer4 = @customers[3]
+    @customer5 = @customers[4]
+    @customer6 = @customers[5]
 
+
+    @invoice1 = create(:invoice, customer: @customer1, created_at:  Time.utc(2004, 9, 13, 12, 0, 0) )
+    @invoices = create_list(:invoice, 2, customer: @customer1)
+    @invoice2 = @invoices[0]
+    @invoice3 = @invoices[1]
+    @invoice4 = create(:invoice, customer_id: @customer2.id, created_at: Time.utc(2004, 9, 13, 12, 0, 0))
+    @invoice5 = create(:invoice, customer_id: @customer3.id, created_at: Time.utc(2006, 1, 12, 1, 0, 0))
+    @invoice6 = create(:invoice, customer_id: @customer4.id, created_at: Time.utc(2024, 4, 5, 12, 0, 0))
+    @invoice7 = create(:invoice, customer_id: @customer5.id, created_at: Time.utc(2024, 4, 6, 12, 0, 0))
+    @invoice8 = create(:invoice, customer_id: @customer6.id, created_at: Time.utc(2024, 4, 7, 12, 0, 0))
+
+    @invoice1_transactions = create_list(:transaction, 4, invoice: @invoice1)
+    @invoice4_transactions = create_list(:transaction, 3, invoice: @invoice4)
+    @invoice5_transactions = create_list(:transaction, 2, invoice: @invoice5)
+
+    @transaction1 = @invoice1_transactions[0]
+    @transaction2 = @invoice1_transactions[1]
+    @transaction3 = @invoice1_transactions[2]
+    @transaction4 = @invoice1_transactions[3]
+    @transaction5 = @invoice4_transactions[0]
+    @transaction6 = @invoice4_transactions[1]
+    @transaction7 = @invoice4_transactions[2]
+    @transaction8 = @invoice5_transactions[0]
+    @transaction9 = @invoice5_transactions[1]
+    @transaction10 = create(:transaction, invoice_id: @invoice2.id)
+    @transaction11 = create(:transaction, invoice_id: @invoice3.id)
+    @transaction12 = create(:transaction, invoice_id: @invoice6.id)
+    @transaction13 = create(:transaction, invoice_id: @invoice7.id)
+
+    @merchant1 = create(:merchant, name: "Amazon")
+
+    @item1 = create(:item, unit_price: 1, merchant_id: @merchant1.id)
+    @item2 = create(:item, unit_price: 23, merchant_id: @merchant1.id)
+    @item3 = create(:item, unit_price: 100, merchant_id: @merchant1.id)
+    @item4 = create(:item, unit_price: 5, merchant_id: @merchant1.id)
+    @item5 = create(:item, unit_price: 12, merchant_id: @merchant1.id)
+
+    @invoice_item1 = create(:invoice_item, item_id: @item1.id, invoice_id: @invoice1.id, status: 0)
+    @invoice_item2 = create(:invoice_item, item_id: @item2.id, invoice_id: @invoice1.id, status: 2)
+    @invoice_item3 = create(:invoice_item, item_id: @item3.id, invoice_id: @invoice2.id, status: 2)
+
+    @invoice_item4 = create(:invoice_item, item_id: @item4.id, invoice_id: @invoice4.id, status: 1)
+    @invoice_item5 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice4.id, status: 1)
+    @invoice_item6 = create(:invoice_item, item_id: @item5.id, invoice_id: @invoice4.id, status: 1)
   end
 
   describe "class methods" do
@@ -24,6 +75,10 @@ RSpec.describe Item, type: :model do
   end
 
   describe "instance methods" do
-    
+    describe ".format_date" do
+      it "formats date day, month, year" do
+        expect(@item1.format_inv_date(@invoice4.id)).to eq("Monday, September 13, 2004")
+      end
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -80,5 +80,18 @@ RSpec.describe Item, type: :model do
         expect(@item1.format_inv_date(@invoice4.id)).to eq("Monday, September 13, 2004")
       end
     end
+
+
+    describe ".order_date" do
+      it "orders invoices by date from oldest to newest" do
+        item1 = create(:item)
+        invoice1 = create(:invoice, created_at: Time.utc(2004, 9, 13, 12, 0, 0))
+        invoice2 = create(:invoice, created_at: Time.utc(2004, 9, 14, 12, 0, 0))
+        invoice_item1 = create(:invoice_item, invoice_id: invoice1.id, item_id: item1.id, quantity: 10, unit_price: 10, status: 1)
+        invoice_item2 = create(:invoice_item, invoice_id: invoice2.id, item_id: item1.id, quantity: 9, unit_price: 9, status: 1)
+
+        expect(item1.order_date).to eq([invoice1, invoice2])
+      end
+    end
   end
 end


### PR DESCRIPTION
US 5: Merchant Dashboard Invoices sorted by least recent

closes #41 

US 10: Merchant Items Grouped by Status

As a merchant,
When I visit my merchant items index page
Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
And I see that each Item is listed in the appropriate section

closes: #36 

US 17: Merchant Invoice Show Page: Total Revenue

As a merchant
When I visit my merchant invoice show page (/merchants/:merchant_id/invoices/:invoice_id)
Then I see the total revenue that will be generated from all of my items on the invoice

closes #29 